### PR TITLE
ci: cd.yml 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,4 +64,6 @@ jobs:
         run: sudo docker logs cogo || true
 
       - name: Delete old docker image
-        run: sudo docker system prune -f
+        run:
+          sudo docker container prune -f
+          sudo docker image prune -f


### PR DESCRIPTION
ec2에 배포 도중 도커 중지 대신 컨테이너와 이미지만 삭제